### PR TITLE
Rouson DOI and news article

### DIFF
--- a/docs/iss/2025-proceedings.md
+++ b/docs/iss/2025-proceedings.md
@@ -166,7 +166,7 @@ year!
     ![Static Badge](https://img.shields.io/badge/LLM-29D680)
 
 
--   #### [Helping Scientists Embrace their Inner Research Software Engineer (RSE) and Working Together with the Community Earth System Model (CESM) RSEs to improve CESM Science](https://ucar-sea.github.io/SEA-ISS-2025-Embrace-Inner-RSE/)
+<!---   #### [Helping Scientists Embrace their Inner Research Software Engineer (RSE) and Working Together with the Community Earth System Model (CESM) RSEs to improve CESM Science](https://ucar-sea.github.io/SEA-ISS-2025-Embrace-Inner-RSE/)
 
     ---
 
@@ -204,7 +204,7 @@ year!
     ![Static Badge](https://img.shields.io/badge/CTSM-29D680)
     ![Static Badge](https://img.shields.io/badge/Earth%20system%20model-29D680)
     ![Static Badge](https://img.shields.io/badge/land%20model-29D680)
-
+-->
 -   #### [Event driven architecture for the IMAP science data center](https://ucar-sea.github.io/SEA-ISS-2025-IMAP-architecture/)
 
     ---
@@ -304,7 +304,7 @@ year!
 
     ---
 
-    [![Static Badge](https://img.shields.io/badge/DOI-10.12345/8ijhF7p-blue)](https://doi.org/10.12345/8ijhF7p)
+    [![Static Badge](https://img.shields.io/badge/DOI-10.5281/zenodo.17070014-blue)](https://doi.org/10.5281/zenodo.17070014)
     [![Static Badge](https://img.shields.io/badge/View_Notebook-F37626?logo=jupyter&logoColor=f5f5f5)](https://ucar-sea.github.io/SEA-ISS-2025-Cloud-microphysics-training/)
     [![Static Badge](https://img.shields.io/badge/GitHub_Repo-181717?logo=github)](https://github.com/UCAR-SEA/SEA-ISS-2025-Cloud-microphysics-training)
   

--- a/docs/posts/20250922-iss2025-proceedings-published.md
+++ b/docs/posts/20250922-iss2025-proceedings-published.md
@@ -22,4 +22,4 @@ behalf of both the submitters and the editorial team; we thank both for their
 efforts and enthusiasm which have helped to make this process a success.
 
 The ISS Conference Committee is in the initial planning stages for the 2026
-Conference. Stay tuned for a additional details later this year.
+Conference. Stay tuned for additional details later this year.

--- a/docs/posts/20250922-iss2025-proceedings-published.md
+++ b/docs/posts/20250922-iss2025-proceedings-published.md
@@ -1,0 +1,25 @@
+---
+draft: false 
+date: 2025-09-22
+authors:
+  - vanderwb
+categories:
+  - ISS Conference
+  - Proceedings
+---
+
+# Presenting the ISS 2025 Conference Proceedings
+
+The 2025 Improving Scientific Software Proceedings Committee is excited to
+present the cumulative efforts of the many authors who wrote and submitted a
+paper to our Conference Proceedings - which are now accessible via the [ISS 2025
+Proceedings Gallery](iss/2025-proceedings).
+
+This year, we decided to experiment with using Jupyter Notebooks as the paper
+format instead of plain-text papers, allowing for greater expressiveness and the
+potential for interactivity in papers. This decision required additional work on
+behalf of both the submitters and the editorial team; we thank both for their
+efforts and enthusiasm which have helped to make this process a success.
+
+The ISS Conference Committee is in the initial planning stages for the 2026
+Conference. Stay tuned for a additional details later this year.


### PR DESCRIPTION
Adds DOI for Rouson paper, a news article announcing the proceedings, and hides Kluzak paper which is still missing a Community DOI.